### PR TITLE
feat: Migrate cat.ddk.xtext.ui.test to Junit5

### DIFF
--- a/com.avaloq.tools.ddk.xtext.ui.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.ui.test/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.xtext.ui,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext.testing,
- org.junit,
  org.mockito,
  com.avaloq.tools.ddk.xtext.ui,
  com.avaloq.tools.ddk.test.core,
@@ -16,6 +15,9 @@ Require-Bundle: org.eclipse.xtext.ui,
  com.avaloq.tools.ddk.xtext.test.core,
  junit-jupiter-api,
  junit-jupiter-engine,
- junit-vintage-engine
+ junit-vintage-engine,
+ net.bytebuddy.byte-buddy,
+ org.objenesis,
+ junit-platform-suite-api
 Export-Package: com.avaloq.tools.ddk.xtext.ui.test
 Automatic-Module-Name: com.avaloq.tools.ddk.xtext.ui.test

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/quickfix/WorkbenchResolutionAdaptorRunTest.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/quickfix/WorkbenchResolutionAdaptorRunTest.java
@@ -43,8 +43,8 @@ import org.eclipse.xtext.ui.util.IssueUtil;
 import org.eclipse.xtext.util.Pair;
 import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.validation.Issue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import com.avaloq.tools.ddk.check.runtime.ui.quickfix.IModificationContextRegistry;
@@ -95,7 +95,7 @@ public class WorkbenchResolutionAdaptorRunTest {
 
   private final WorkbenchMarkerResolutionGenerator wmrg = injector.getInstance(WorkbenchMarkerResolutionGenerator.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     wmrg.setIssueUtil(new IssueUtil());
 

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/quickfix/WorkbenchResolutionAdaptorTest.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/quickfix/WorkbenchResolutionAdaptorTest.java
@@ -11,8 +11,8 @@
 
 package com.avaloq.tools.ddk.xtext.ui.quickfix;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,8 +21,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
 import org.eclipse.xtext.ui.util.IssueUtil;
 import org.eclipse.xtext.validation.Issue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.avaloq.tools.ddk.xtext.ui.quickfix.WorkbenchMarkerResolutionGenerator.WorkbenchResolutionAdapter;
 
@@ -37,7 +37,7 @@ public class WorkbenchResolutionAdaptorTest {
 
   private final WorkbenchMarkerResolutionGenerator mockWmrg = mock(WorkbenchMarkerResolutionGenerator.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     when(mockWmrg.getIssueUtil()).thenReturn(new IssueUtil());
   }
@@ -51,7 +51,7 @@ public class WorkbenchResolutionAdaptorTest {
 
     WorkbenchResolutionAdapter adapter = mockWmrg.new WorkbenchResolutionAdapter(mockIssueResolution, mockMarker);
 
-    assertEquals("Adapter delegates get label to resolution.", TEST_LABEL, adapter.getLabel()); //$NON-NLS-1$
+    assertEquals(TEST_LABEL, adapter.getLabel(), "Adapter delegates get label to resolution."); //$NON-NLS-1$
   }
 
   @Test
@@ -63,7 +63,7 @@ public class WorkbenchResolutionAdaptorTest {
 
     WorkbenchResolutionAdapter adapter = mockWmrg.new WorkbenchResolutionAdapter(mockIssueResolution, mockMarker);
 
-    assertEquals("Adapter delegates get description to resolution.", TEST_DESCRIPTION, adapter.getDescription()); //$NON-NLS-1$
+    assertEquals(TEST_DESCRIPTION, adapter.getDescription(), "Adapter delegates get description to resolution."); //$NON-NLS-1$
   }
 
   @Test
@@ -75,7 +75,7 @@ public class WorkbenchResolutionAdaptorTest {
 
     WorkbenchResolutionAdapter adapter = mockWmrg.new WorkbenchResolutionAdapter(mockIssueResolution, mockMarker);
 
-    assertEquals("Adapter delegates get Image to resolution.", TEST_IMAGE, adapter.getImage()); //$NON-NLS-1$
+    assertEquals(TEST_IMAGE, adapter.getImage(), "Adapter delegates get Image to resolution."); //$NON-NLS-1$
   }
 
   @Test
@@ -95,14 +95,14 @@ public class WorkbenchResolutionAdaptorTest {
 
     WorkbenchResolutionAdapter adapter = mockWmrg.new WorkbenchResolutionAdapter(mockIssueResolution, mockResolutionMarker);
 
-    assertArrayEquals("Adapter findOtherMarkers matching on CODE1.", matchingMarkers, adapter.findOtherMarkers(allMarkers)); //$NON-NLS-1$
+    assertArrayEquals(matchingMarkers, adapter.findOtherMarkers(allMarkers), "Adapter findOtherMarkers matching on CODE1."); //$NON-NLS-1$
 
     when(mockResolutionMarker.getAttribute(Issue.CODE_KEY, null)).thenReturn(CODE2);
     matchingMarkers = new IMarker[] {mockMarker2};
 
     adapter = mockWmrg.new WorkbenchResolutionAdapter(mockIssueResolution, mockResolutionMarker);
 
-    assertArrayEquals("Adapter findOtherMarkers matching on CODE2.", matchingMarkers, adapter.findOtherMarkers(allMarkers)); //$NON-NLS-1$
+    assertArrayEquals(matchingMarkers, adapter.findOtherMarkers(allMarkers), "Adapter findOtherMarkers matching on CODE2."); //$NON-NLS-1$
 
   }
 

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/ResourceNameTemplateVariableResolverTest.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/ResourceNameTemplateVariableResolverTest.java
@@ -11,25 +11,29 @@
 
 package com.avaloq.tools.ddk.xtext.ui.templates;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.templates.TemplateException;
 import org.eclipse.jface.text.templates.TemplateVariable;
 import org.eclipse.xtext.XtextRuntimeModule;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContext;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
-import com.avaloq.tools.ddk.test.core.AfterAll;
-import com.avaloq.tools.ddk.test.core.BeforeAll;
-import com.avaloq.tools.ddk.xtext.test.junit.runners.XtextClassRunner;
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;
 
 
-@RunWith(XtextClassRunner.class)
+@ExtendWith(InjectionExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ResourceNameTemplateVariableResolverTest {
 
   private static final Object[] FILE = new Object[] {"file"}; //$NON-NLS-1$
@@ -66,14 +70,14 @@ public class ResourceNameTemplateVariableResolverTest {
     resolver = null;
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testResolveValuesWithNullVariable() {
-    resolver.resolveValues(null, mockContext);
+    assertThrows(NullPointerException.class, () -> resolver.resolveValues(null, mockContext));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testResolveValuesWithNullContext() {
-    resolver.resolveValues(Mockito.mock(TemplateVariable.class), null);
+    assertThrows(NullPointerException.class, () -> resolver.resolveValues(Mockito.mock(TemplateVariable.class), null));
   }
 
   @Test
@@ -121,7 +125,7 @@ public class ResourceNameTemplateVariableResolverTest {
     final String[] actualResolvedValues = Iterables.toArray(resolver.resolveValues(variable, mockContext), String.class);
 
     // ASSERT
-    Assert.assertArrayEquals("Resolved values", expectedResolvedValues, actualResolvedValues); //$NON-NLS-1$
+    assertArrayEquals(expectedResolvedValues, actualResolvedValues, "Resolved values"); //$NON-NLS-1$
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/SimpleEnumTemplateVariableResolverTest.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/SimpleEnumTemplateVariableResolverTest.java
@@ -11,7 +11,8 @@
 
 package com.avaloq.tools.ddk.xtext.ui.templates;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
@@ -19,17 +20,19 @@ import java.util.List;
 import org.eclipse.jface.text.templates.TemplateException;
 import org.eclipse.jface.text.templates.TemplateVariable;
 import org.eclipse.xtext.XtextRuntimeModule;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.avaloq.tools.ddk.test.core.AfterAll;
-import com.avaloq.tools.ddk.test.core.BeforeAll;
-import com.avaloq.tools.ddk.xtext.test.junit.runners.XtextClassRunner;
 import com.google.inject.Guice;
 
 
-@RunWith(XtextClassRunner.class)
+@ExtendWith(InjectionExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SimpleEnumTemplateVariableResolverTest {
 
   private static XtextTemplateContext mockContext;
@@ -50,9 +53,9 @@ public class SimpleEnumTemplateVariableResolverTest {
     resolver = null;
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testResolveValuesWithNullVariable() {
-    resolver.resolveValues(null, mockContext);
+    assertThrows(NullPointerException.class, () -> resolver.resolveValues(null, mockContext));
   }
 
   @Test
@@ -73,7 +76,7 @@ public class SimpleEnumTemplateVariableResolverTest {
     final List<String> resolvedValues = resolver.resolveValues(variable, mockContext);
 
     // ASSERT
-    assertArrayEquals("Resolved values", values, resolvedValues.toArray(new String[resolvedValues.size()])); //$NON-NLS-1$
+    assertArrayEquals(values, resolvedValues.toArray(new String[resolvedValues.size()]), "Resolved values"); //$NON-NLS-1$
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/TemplateProposalProviderHelperTest.xtend
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/TemplateProposalProviderHelperTest.xtend
@@ -11,29 +11,32 @@
 
 package com.avaloq.tools.ddk.xtext.ui.templates
 
-import com.avaloq.tools.ddk.test.core.AfterAll
-import com.avaloq.tools.ddk.test.core.BeforeAll
-import com.avaloq.tools.ddk.xtext.test.junit.runners.XtextClassRunner
 import com.google.inject.Guice
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.Position
 import org.eclipse.jface.text.templates.Template
 import org.eclipse.xtext.XtextRuntimeModule
+import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContext
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContextType
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
 
-import static org.junit.Assert.assertArrayEquals
-import static org.junit.Assert.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertArrayEquals
 import static org.mockito.ArgumentMatchers.anyInt
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 import static org.mockito.Mockito.when
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.AfterAll
 
-@RunWith(XtextClassRunner)
+@ExtendWith(InjectionExtension)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TemplateProposalProviderHelperTest {
 
   static val SIMPLE_ENUM_VARIABLE_TYPE = new SimpleEnumTemplateVariableResolver().type
@@ -80,14 +83,14 @@ class TemplateProposalProviderHelperTest {
     helper = null
   }
 
-  @Test(expected=NullPointerException)
+  @Test
   def void testCreateLiteralValuePatternWithNullName() {
-    helper.createLiteralValuePattern(null, 42)
+    assertThrows(NullPointerException, [| helper.createLiteralValuePattern(null, 42)])
   }
 
-  @Test(expected=IllegalArgumentException)
+  @Test
   def void testCreateLiteralValuePatternWithNameContainingWhitespace() {
-    helper.createLiteralValuePattern("Contains whitespace", 42)
+    assertThrows(IllegalArgumentException, [| helper.createLiteralValuePattern("Contains whitespace", 42)])
   }
 
   @Test
@@ -134,37 +137,36 @@ class TemplateProposalProviderHelperTest {
 
     // ASSERT
     verify(helperSpy).createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, VARIABLE_NAME, defaultValue)
-    assertEquals("Expected result", expectedResult, actualResult)
+    assertEquals(expectedResult, actualResult, "Expected result")
   }
 
-  @Test(expected=NullPointerException)
+  @Test
   def void testCreateTemplateVariablePatternWithNullType() {
-    helper.createTemplateVariablePattern(null, VARIABLE_NAME)
+    assertThrows(NullPointerException, [| helper.createTemplateVariablePattern(null, VARIABLE_NAME)])
   }
 
-  @Test(expected=IllegalArgumentException)
+  @Test
   def void testCreateTemplateVariablePatternWithTypeContainingWhitespace() {
-    helper.createTemplateVariablePattern("Contains whitespace", VARIABLE_NAME)
+    assertThrows(IllegalArgumentException, [|helper.createTemplateVariablePattern("Contains whitespace", VARIABLE_NAME)])
   }
 
-  @Test(expected=NullPointerException)
+  @Test
   def void testCreateTemplateVariablePatternWithNullName() {
-    helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, null)
+    assertThrows(NullPointerException, [| helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, null)])
   }
 
-  @Test(expected=IllegalArgumentException)
   def void testCreateTemplateVariablePatternWithNameContainingWhitespace() {
-    helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, "Contains whitespace")
+    assertThrows(IllegalArgumentException, [| helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, "Contains whitespace")])
   }
 
-  @Test(expected=NullPointerException)
+  @Test
   def void testCreateTemplateVariablePatternWithNull() {
-    helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, VARIABLE_NAME, null)
+    assertThrows(NullPointerException, [| helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, VARIABLE_NAME, null)])
   }
 
-  @Test(expected=IllegalArgumentException)
+  @Test
   def void testCreateTemplateVariablePatternWithNoValues() {
-    helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, VARIABLE_NAME)
+    assertThrows(IllegalArgumentException, [| helper.createTemplateVariablePattern(SIMPLE_ENUM_VARIABLE_TYPE, VARIABLE_NAME)])
   }
 
   @Test
@@ -256,8 +258,8 @@ class TemplateProposalProviderHelperTest {
     val actualValues = templateBuffer.variables.get(0).values
 
     // ASSERT
-    assertEquals("Expected result", expectedResult, actualResult)
-    assertArrayEquals("Expected values", expectedValues, actualValues)
+    assertEquals(expectedResult, actualResult, "Expected result")
+    assertArrayEquals(expectedValues, actualValues, "Expected values")
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/TemplateVariableResolverTestHelper.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/TemplateVariableResolverTestHelper.java
@@ -11,7 +11,7 @@
 
 package com.avaloq.tools.ddk.xtext.ui.templates;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.text.templates.TemplateException;
 import org.eclipse.jface.text.templates.TemplateTranslator;
@@ -55,7 +55,7 @@ public class TemplateVariableResolverTestHelper {
     // and has protected constructors thus cannot be directly instantiated
     final String pattern = helper.createTemplateVariablePattern(resolver.getType(), name, values);
     final TemplateVariable[] variables = translator.translate(pattern).getVariables();
-    assertEquals("Exactly one variable should be returned", 1, variables.length); //$NON-NLS-1$
+    assertEquals(1, variables.length, "Exactly one variable should be returned"); //$NON-NLS-1$
     return variables[0];
   }
 

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/test/XtextUiTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/test/XtextUiTestSuite.java
@@ -11,7 +11,8 @@
 
 package com.avaloq.tools.ddk.xtext.ui.test;
 
-import org.junit.runner.RunWith;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 import com.avaloq.tools.ddk.test.core.junit.runners.DiscerningSuite;
 import com.avaloq.tools.ddk.xtext.ui.quickfix.WorkbenchResolutionAdaptorRunTest;
@@ -22,10 +23,10 @@ import com.avaloq.tools.ddk.xtext.ui.templates.TemplateProposalProviderHelperTes
 
 
 /**
- * Empty class serving only as holder for JUnit4 annotations.
+ * Junit5 version of test suites. does not implement the logic in our {@link DiscerningSuite}.
  */
-@RunWith(DiscerningSuite.class)
-@DiscerningSuite.SuiteClasses({
+@Suite
+@SelectClasses({
 // @Format-Off
   WorkbenchResolutionAdaptorTest.class,
   WorkbenchResolutionAdaptorRunTest.class,


### PR DESCRIPTION
removed junit4 dependencies
removed dependency to DiscerningSuite. Once we migrate the DiscerningSuite to Junit5 we can use it again here